### PR TITLE
Ranch 2.1 compatibility

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,15 +7,12 @@
 ]}.
 
 {deps, [
-    {nklib, ".*", {git, "https://github.com/michalwski/nklib.git", {ref, "006c1b7"}}},
-	% {cowboy, ".*", {git, "https://github.com/extend/cowboy", {tag, "1.0.3"}}},
-	{ranch, ".*", {git, "https://github.com/ninenines/ranch.git", {tag, "1.1.0"}}},
-	{cowlib, ".*", {git, "https://github.com/ninenines/cowlib.git", {tag, "1.3.0"}}},
-	{cowboy, ".*", {git, "https://github.com/extend/cowboy",
-					"90ae31998e8d0887b9efe4b441136ac047708bb9"}},
+        {nklib, ".*", {git, "https://github.com/michalwski/nklib.git", {ref, "006c1b7"}}},
+        {ranch, "2.1.0"},
+        {cowboy, "2.9.0"},
 	% {enm, ".*", {git, "https://github.com/basho/enm.git", {branch, "master"}}},
 
 	% Used for tests
 	{gun, ".*", {git, "https://github.com/ninenines/gun.git",
-				"427230d6f94f5b8a396fd504a73d73d1d65ab0a7"}}
+                     {ref, "427230d6f94f5b8a396fd504a73d73d1d65ab0a7"}}}
 ]}.


### PR DESCRIPTION
Support ranch 2.1, which is required by [mongoose c2s](https://github.com/esl/MongooseIM/tree/feature/mongoose_c2s).

The target branch is now called `mongooseim-ranch-compatibility`, and is an exact copy of https://github.com/michalwski/nkpacket/tree/ranch-1.7-compatibility, which was used by MongooseIM. That branch contained a quick fix, which enabled using the `nksip` listener with MongooseIM. However, the support for ranch 1.7 was only partial, and functionality not required by MongooseIM was not working.

I decided to continue on that route to avoid any significant rewrite of the library, because MongooseIM is only using a small part of it. As a result, the change only enables listening for and accepting TCP connections with ranch 2.1. The `jingle_SUITE` passes in MongooseIM. Unfortunately we don't have any further tests, but I think that the functionality is a lower-priority one, and this should be enough for now.

