### PR TITLE
Remove lager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,6 @@ cleanplt:
 
 
 build_tests:
-	erlc -pa ebin -pa deps/lager/ebin -pa deps/nklib/ebin -o ebin -I include \
-	+export_all +debug_info +"{parse_transform, lager_transform}" \
+	erlc -pa ebin -pa deps/nklib/ebin -o ebin -I include \
+	+export_all +debug_info \
 	test/*.erl

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ ext_ip, if auto, is obtained using STUN.
 None of them are used by nkpacket itself, but are available for client projects.
 
 
-NkPACKET uses [lager](https://github.com/basho/lager) for log management. 
+NkPACKET uses [logger](https://github.com/basho/logger) for log management.
 
 NkPACKET needs Erlang >= 17 and it is tested on Linux and OSX.
 

--- a/include/nkpacket.hrl
+++ b/include/nkpacket.hrl
@@ -33,7 +33,7 @@
 
 -define(
     DO_LOG(Level, Domain, Text, Opts),
-        lager:Level([{domain, Domain}], "~p "++Text, [Domain|Opts])).
+        logger:Level("~p "++Text, [Domain|Opts])).
 
 -define(debug(Domain, Text, List), 
     ?DO_LOG(debug, Domain, Text, List)).

--- a/rebar.config
+++ b/rebar.config
@@ -1,16 +1,13 @@
 {cover_enabled, true}.
 
 {erl_opts, [
-	debug_info,
-	fail_on_warning,
-    {parse_transform, lager_transform}
+	debug_info
 ]}.
 
 {deps, [
-        {nklib, ".*", {git, "https://github.com/michalwski/nklib.git", {ref, "006c1b7"}}},
+        {nklib, ".*", {git, "https://github.com/esl/nklib.git", {branch, "remove-lager"}}},
         {ranch, "2.1.0"},
         {cowboy, "2.9.0"},
-	% {enm, ".*", {git, "https://github.com/basho/enm.git", {branch, "master"}}},
 
 	% Used for tests
 	{gun, ".*", {git, "https://github.com/ninenines/gun.git",

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 ]}.
 
 {deps, [
-        {nklib, ".*", {git, "https://github.com/esl/nklib.git", {branch, "remove-lager"}}},
+        {nklib, ".*", {git, "https://github.com/esl/nklib.git", {branch, "mongooseim"}}},
         {ranch, "2.1.0"},
         {cowboy, "2.9.0"},
 

--- a/src/nkpacket.app.src
+++ b/src/nkpacket.app.src
@@ -10,7 +10,6 @@
         crypto,
         sasl,
         ssl,
-        lager,
         ssh,
         ranch,
         cowlib,

--- a/src/nkpacket_app.erl
+++ b/src/nkpacket_app.erl
@@ -61,15 +61,15 @@ start(_Type, _Args) ->
             nkpacket_util:make_cache(),
             {ok, Pid} = nkpacket_sup:start_link(),
             {ok, Vsn} = application:get_key(nkpacket, vsn),
-            lager:info("NkPACKET v~s has started.", [Vsn]),
+            logger:info("NkPACKET v~s has started.", [Vsn]),
             MainIp = nklib_util:to_host(nkpacket_app:get(main_ip)),
             MainIp6 = nklib_util:to_host(nkpacket_app:get(main_ip6)),
             ExtIp = nklib_util:to_host(nkpacket_app:get(ext_ip)),
-            lager:info("Main IP is ~s (~s). External IP is ~s", 
+            logger:info("Main IP is ~s (~s). External IP is ~s", 
                        [MainIp, MainIp6, ExtIp]),
             {ok, Pid};
         {error, Error} ->
-            lager:error("Config error: ~p", [Error]),
+            logger:error("Config error: ~p", [Error]),
             error(config_error)
     end.
 

--- a/src/nkpacket_connection_lib.erl
+++ b/src/nkpacket_connection_lib.erl
@@ -85,7 +85,7 @@ raw_send(#nkport{transp=tcp, socket=Socket}, Data, _Opts) ->
     gen_tcp:send(Socket, Data);
 
 raw_send(#nkport{transp=tls, socket=Socket}, Data, _Opts) ->
-    % lager:warning("Send: ~p", [list_to_binary([Data])]),
+    % logger:warning("Send: ~p", [list_to_binary([Data])]),
     ssl:send(Socket, Data);
 
 raw_send(#nkport{transp=sctp, socket={Socket, AssocId}}, Data, _Opts) ->

--- a/src/nkpacket_connection_ws.erl
+++ b/src/nkpacket_connection_ws.erl
@@ -63,12 +63,12 @@ start_handshake(NkPort) ->
         ws -> ranch_tcp;
         wss -> ranch_ssl
     end,
-    lager:debug("sending ws request: ~s", [print_headers(list_to_binary(Req))]),
+    logger:debug("sending ws request: ~s", [print_headers(list_to_binary(Req))]),
     case TranspMod:send(Socket, Req) of
         ok ->
             case recv(TranspMod, Socket, <<>>) of
                 {ok, Data} ->
-                    lager:debug("received ws reply: ~s", [print_headers(Data)]),
+                    logger:debug("received ws reply: ~s", [print_headers(Data)]),
                     case get_handshake_resp(Data, Key) of
                         {ok, WsProto, Rest} ->
                             {ok, WsProto, Rest};

--- a/src/nkpacket_cowboy.erl
+++ b/src/nkpacket_cowboy.erl
@@ -247,7 +247,7 @@ init([NkPort, Filter]) ->
             },
             {ok, register(State)};
         {error, Error} ->
-            lager:error("could not start ~p transport on ~p:~p (~p)", 
+            logger:error("could not start ~p transport on ~p:~p (~p)", 
                    [Transp, ListenIp, ListenPort, Error]),
             {stop, Error}
     end.
@@ -275,7 +275,7 @@ handle_call(get_state, _From, State) ->
     {reply, State, State};
 
 handle_call(Msg, _From, State) ->
-    lager:error("Module ~p received unexpected call: ~p", [?MODULE, Msg]),
+    logger:error("Module ~p received unexpected call: ~p", [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -284,7 +284,7 @@ handle_call(Msg, _From, State) ->
     {noreply, #state{}} | {stop, term(), #state{}}.
 
 handle_cast(Msg, State) ->
-    lager:error("Module ~p received unexpected cast: ~p", [?MODULE, Msg]),
+    logger:error("Module ~p received unexpected cast: ~p", [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -296,13 +296,13 @@ handle_info({'DOWN', MRef, process, _Pid, _Reason}=Msg, State) ->
     #state{filters=Filters} = State,
     case lists:keytake(MRef, #filter.mon, Filters) of
         {value, _, []} ->
-            % lager:debug("Last server leave"),
+            % logger:debug("Last server leave"),
             {stop, normal, State};
         {value, _, Filters1} ->
-            % lager:debug("Server leave"),
+            % logger:debug("Server leave"),
             {noreply, register(State#state{filters=Filters1})};
         false ->
-            lager:warning("Module ~p received unexpected info: ~p", [?MODULE, Msg]),
+            logger:warning("Module ~p received unexpected info: ~p", [?MODULE, Msg]),
             {noreply, State}
     end;
 
@@ -310,7 +310,7 @@ handle_info({'EXIT', Pid, Reason}, #state{ranch_pid=Pid}=State) ->
     {stop, {ranch_stop, Reason}, State};
 
 handle_info(Msg, State) ->
-    lager:warning("Module ~p received unexpected info: ~p", [?MODULE, Msg]),
+    logger:warning("Module ~p received unexpected info: ~p", [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -327,7 +327,7 @@ code_change(_OldVsn, State, _Extra) ->
     ok.
 
 terminate(Reason, #state{ranch_pid=RanchPid}=State) ->  
-    lager:debug("Cowboy listener stop: ~p", [Reason]),
+    logger:debug("Cowboy listener stop: ~p", [Reason]),
     #state{
         ranch_id = RanchId,
         nkport = #nkport{transp=Transp, socket=Socket}
@@ -366,14 +366,14 @@ start_link(Ref, Socket, TranspModule, Opts) ->
 % start_cowboy_wait(Pid) ->
 %     receive
 %         {'EXIT', Pid, Reason} ->
-%             lager:warning("COWBOY EXIT: ~p", [Reason]);
+%             logger:warning("COWBOY EXIT: ~p", [Reason]);
 %         Other ->
-%             lager:warning("OTHER: ~p", [Other]),
+%             logger:warning("OTHER: ~p", [Other]),
 %             Pid ! Other,
 %             start_cowboy_wait(Pid)
 %     after 
 %         30000 ->
-%             lager:warning("COWBOY EXIT!!")
+%             logger:warning("COWBOY EXIT!!")
 %     end.
 
 
@@ -393,7 +393,7 @@ execute(Req, Env) ->
     term().
 
 execute([], Req, _Env) ->
-    lager:info("NkPACKET Cowboy: url ~s not matched", [cowboy_req:path(Req)]),
+    logger:info("NkPACKET Cowboy: url ~s not matched", [cowboy_req:path(Req)]),
     {stop, reply(404, Req)};
 
 execute([Filter|Rest], Req, Env) ->
@@ -429,7 +429,7 @@ execute([Filter|Rest], Req, Env) ->
         check_paths(ReqPaths, Paths)
     of
         true ->
-            lager:debug("NkPACKET Web Selected: ~p (~p) ~p (~p), ~p (~p), ~p (~p)", 
+            logger:debug("NkPACKET Web Selected: ~p (~p) ~p (~p), ~p (~p), ~p (~p)", 
                 [ReqType, Type, ReqHost, Host, ReqPaths, Paths, ReqWsProto, WsProto]),
             Req1 = case WsProto of
                 any -> 
@@ -445,7 +445,7 @@ execute([Filter|Rest], Req, Env) ->
                     Result
             end;
         false ->
-            lager:debug("NkPACKET Web Skipping: ~p (~p) ~p (~p), ~p (~p), ~p (~p)", 
+            logger:debug("NkPACKET Web Skipping: ~p (~p) ~p (~p), ~p (~p), ~p (~p)", 
                 [ReqType, Type, ReqHost, Host, ReqPaths, Paths, ReqWsProto, WsProto]),
             execute(Rest, Req, Env)
     end.

--- a/src/nkpacket_cowboy_static.erl
+++ b/src/nkpacket_cowboy_static.erl
@@ -24,7 +24,7 @@
 -type state() :: {file, #file_info{}, opts()} | {error, atom()}.
 
 
--define(LOG(Txt, List), lager:notice("Webserver "++Txt, List)).
+-define(LOG(Txt, List), logger:notice("Webserver "++Txt, List)).
 
 
 %% ===================================================================
@@ -46,7 +46,7 @@ init(Req, #{path:=DirPath}=Opts) ->
 			IsDir = binary:last(cowboy_req:url(Req)) == $/,
 			init_file(Req1, Opts, FilePath, IsDir);
 		_ ->
-			lager:warning("Webserver trying to access forbidden ~s", [FilePath]),
+			logger:warning("Webserver trying to access forbidden ~s", [FilePath]),
 			{cowboy_rest, Req1, {error, malformed}}
 	end.
 
@@ -60,25 +60,25 @@ init_file(Req, Opts, FilePath, IsDir) ->
 		{ok, #file_info{type=directory}} when IsDir ->
 			case maps:get(index_file, Opts, undefined) of
 				undefined -> 
-					lager:debug("Webserver didn't allow directory ~s", [FilePath]),
+					logger:debug("Webserver didn't allow directory ~s", [FilePath]),
 					{cowboy_rest, Req, {error, forbidden}};
 				Index ->
 					Index1 = nklib_util:to_binary(Index),
 					FilePath2 = <<FilePath/binary, "/", Index1/binary>>,
-					lager:debug("Webserver sending index file ~s", [FilePath2]),
+					logger:debug("Webserver sending index file ~s", [FilePath2]),
 					init_file(Req, maps:remove(index_file, Opts), FilePath2, false)
 			end;
 		{ok, #file_info{type=directory}} when not IsDir ->
 			Url = <<(cowboy_req:url(Req))/binary, "/">>,
-			lager:debug("Webserver sent redirect to ~s", [Url]),
+			logger:debug("Webserver sent redirect to ~s", [Url]),
 			Req2 = cowboy_req:set_resp_header(<<"location">>, Url, Req),
 			Req3 = cowboy_req:reply(301, Req2),
 			{ok, Req3, Opts};
 		{ok, #file_info{}=File} ->
-			lager:debug("Webserver found file ~s", [FilePath]),
+			logger:debug("Webserver found file ~s", [FilePath]),
 			{cowboy_rest, Req, {file, File, Opts#{path:=FilePath}}};
 		{error, enoent} ->
-			lager:info("Webserver didn't find file ~s", [FilePath]),
+			logger:info("Webserver didn't find file ~s", [FilePath]),
 			{cowboy_rest, Req, {error, not_found}};
 		_ ->
 			{cowboy_rest, Req, {error, forbidden}}

--- a/src/nkpacket_dns.erl
+++ b/src/nkpacket_dns.erl
@@ -188,7 +188,7 @@ naptr(Scheme, Domain, #{protocol:=Protocol}=Opts) when Protocol/=undefined ->
                 undefined ->
                     Naptr = lists:sort(inet_res:lookup(Domain1, in, naptr)),
                     save_cache({naptr, Domain1}, Naptr),
-                    lager:debug("Naptr: ~p", [Naptr]),
+                    logger:debug("Naptr: ~p", [Naptr]),
                     naptr(Scheme, Naptr, Protocol, Opts, []);
                 Naptr ->
                     naptr(Scheme, Naptr, Protocol, Opts, [])
@@ -252,7 +252,7 @@ srvs(Domain, Opts) ->
         [] -> 
             [];
         _ -> 
-            lager:debug("Srvs: ~p", [List]),
+            logger:debug("Srvs: ~p", [List]),
             lists:flatten([
                 [{Addr, Port} || Addr <- ips(Host, Opts)] || {Host, Port} <- List
             ])
@@ -279,7 +279,7 @@ ips(Host, Opts) ->
         undefined ->
             case inet:getaddrs(Host1, inet) of
                 {ok, [Ip, Ip]} ->
-                    lager:debug("Duplicted IP from inet:getaddrs/2"),
+                    logger:debug("Duplicted IP from inet:getaddrs/2"),
                     Ips = [Ip];
                 {ok, Ips} -> 
                     ok;
@@ -347,7 +347,7 @@ init([]) ->
     {stop, term(), #state{}} | {stop, term(), term(), #state{}}.
 
 handle_call(Msg, _From, State) -> 
-    lager:error("Module ~p received unexpected call ~p", [?MODULE, Msg]),
+    logger:error("Module ~p received unexpected call ~p", [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -356,7 +356,7 @@ handle_call(Msg, _From, State) ->
     {noreply, #state{}} | {stop, term(), #state{}}.
 
 handle_cast(Msg, State) -> 
-    lager:error("Module ~p received unexpected cast ~p", [?MODULE, Msg]),
+    logger:error("Module ~p received unexpected cast ~p", [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -373,7 +373,7 @@ handle_info({timeout, _, check_ttl}, State) ->
     {noreply, State};
 
 handle_info(Info, State) -> 
-    lager:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
+    logger:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
     {noreply, State}.
 
 
@@ -451,7 +451,7 @@ get_transp(_Scheme, Transp, _Opts) ->
 get_port(0, Transp, #{protocol:=Protocol}) when Protocol/=undefined ->
     case erlang:function_exported(Protocol, default_port, 1) of
         true ->
-            % lager:warning("P: ~p, ~p", [Protocol, Transp]),
+            % logger:warning("P: ~p, ~p", [Protocol, Transp]),
             case Protocol:default_port(Transp) of
                 Port when is_integer(Port) -> Port;
                 _ -> throw({invalid_transport, Transp})

--- a/src/nkpacket_protocol_http.erl
+++ b/src/nkpacket_protocol_http.erl
@@ -68,7 +68,7 @@ http_init(HttpProto, _ConnPid, Req, Env) ->
  			Env1 = nklib_util:store_values(UserEnv, Env),
  			{ok, Req, Env1, Middlewares};
  		_ ->
- 			lager:warning("Invalid HTTP Protocol: ~p", [HttpProto]),
+ 			logger:warning("Invalid HTTP Protocol: ~p", [HttpProto]),
 			{stop, nkpacket_cowboy:reply(500, Req)}
  	end.
 

--- a/src/nkpacket_stun.erl
+++ b/src/nkpacket_stun.erl
@@ -221,14 +221,14 @@ get_stun_servers([], _Socket, _Local, List) ->
         [ExtIp] ->
             ok;
         [ExtIp|_] = All ->
-            lager:error("STUN multiple external IPs!!: ~p", [All]);
+            logger:error("STUN multiple external IPs!!: ~p", [All]);
         [] ->
             ExtIp = {127,0,0,1},
-            lager:notice("STUN could not find external IP!!")
+            logger:notice("STUN could not find external IP!!")
     end,
     case lists:keymember(port_changed, 2, List) of
         true ->
-            lager:warning("Current NAT is changing ports!");
+            logger:warning("Current NAT is changing ports!");
         false ->
             ok
     end,
@@ -254,10 +254,10 @@ get_stun_servers([Uri|Rest], Socket, Local, Acc) ->
     end,
     case Ips of
         [] ->
-            lager:notice("Skipping STUN ~s", [Host]),
+            logger:notice("Skipping STUN ~s", [Host]),
             get_stun_servers(Rest, Socket, Local, Acc);
         _ ->
-            lager:info("Checking STUN ~s", [Host]),
+            logger:info("Checking STUN ~s", [Host]),
             Acc2 = check_stun_server(Ips, Port, Socket, Local, Acc),
             get_stun_servers(Rest, Socket, Local, Acc2)
     end.
@@ -280,7 +280,7 @@ check_stun_server([Ip|Rest], Port, Socket, LocalPort, Acc) ->
             case decode(Raw) of
                 {response, binding, Id, Data} ->
                     Time = (nklib_util:l_timestamp() - Start) div 1000,
-                    % lager:info("STUN server ~p: ~p msecs", [Ip, Time]),
+                    % logger:info("STUN server ~p: ~p msecs", [Ip, Time]),
                     case proplists:get_value(mapped_address, Data) of
                         {RemoteIp, LocalPort} ->
                             [{RemoteIp, ok, Ip, Port2, Time}|Acc];

--- a/src/nkpacket_transport.erl
+++ b/src/nkpacket_transport.erl
@@ -114,10 +114,10 @@ send([Uri|Rest], Msg, Opts) when is_binary(Uri); is_list(Uri) ->
 send([#uri{}=Uri|Rest], Msg, Opts) ->
     case nkpacket:resolve(Uri, Opts) of
         {ok, RawConns, Opts1} ->
-            lager:debug("transport send to ~p (~p)", [RawConns, Rest]),
+            logger:debug("transport send to ~p (~p)", [RawConns, Rest]),
             send(RawConns++Rest, Msg, Opts1);
         {error, Error} ->
-            lager:notice("Error sending to ~p: ~p", [Uri, Error]),
+            logger:notice("Error sending to ~p: ~p", [Uri, Error]),
             send(Rest, Msg, Opts#{last_error=>Error})
     end;
 
@@ -127,7 +127,7 @@ send([#nkport{socket=undefined}=NkPort|Rest], Msg, Opts) ->
     send([{current, Conn}|Rest], Msg, Opts);
 
 send([Port|Rest], Msg, Opts) when is_pid(Port); is_record(Port, nkport) ->
-    lager:debug("transport send to nkport ~p", [Port]),
+    logger:debug("transport send to nkport ~p", [Port]),
     case do_send(Msg, [Port], Opts#{udp_to_tcp=>false}) of
         {ok, Res} -> {ok, Res};
         {error, Opts1} -> send(Rest, Msg, Opts1)
@@ -151,7 +151,7 @@ send([{Protocol, Transp, Ip, 0}|Rest], Msg, Opts) ->
 send([{connect, Conn}|Rest], Msg, Opts) ->
     RemoveOpts = [udp_to_tcp, last_error],
     ConnOpts = maps:without(RemoveOpts, Opts),
-    lager:debug("transport connecting to ~p (~p)", [Conn, ConnOpts]),
+    logger:debug("transport connecting to ~p (~p)", [Conn, ConnOpts]),
     case connect([Conn], ConnOpts) of
         {ok, Pid} ->
             case do_send(Msg, [Pid], Opts) of
@@ -164,7 +164,7 @@ send([{connect, Conn}|Rest], Msg, Opts) ->
                     send(Rest, Msg, Opts1)
             end;
         {error, Error} ->
-            lager:info("Error connecting to ~p: ~p", [Conn, Error]),
+            logger:info("Error connecting to ~p: ~p", [Conn, Error]),
             send(Rest, Msg, Opts#{last_error=>Error})
     end;
 
@@ -175,11 +175,11 @@ send([{_, _, _, _}=Conn|Rest], Msg, #{class:=_}=Opts) ->
     end,
     case do_send(Msg, Pids, Opts) of
         {ok, Res} -> 
-            lager:debug("transport used previous connection to ~p (~p)", [Conn, Opts]),
+            logger:debug("transport used previous connection to ~p (~p)", [Conn, Opts]),
             {ok, Res};
         retry_tcp ->
             Conn1 = setelement(2, Conn, tcp), 
-            lager:debug("transport retrying with tcp", []),
+            logger:debug("transport retrying with tcp", []),
             send([Conn1|Rest], Msg, Opts);
         {error, Opts1} -> 
             send([{connect, Conn}|Rest], Msg, Opts1)
@@ -190,7 +190,7 @@ send([{_, _, _, _}=Conn|Rest], Msg, Opts) ->
     send([{connect, Conn}|Rest], Msg, Opts);
 
 send([Term|Rest], Msg, Opts) ->
-    lager:warning("Invalid send specification: ~p", [Term]),
+    logger:warning("Invalid send specification: ~p", [Term]),
     send(Rest, Msg, Opts#{last_error=>{invalid_send_specification, Term}});
 
 send([], _Msg, #{last_error:=Error}) -> 
@@ -232,11 +232,11 @@ do_send(Msg, [Port|Rest], Opts) ->
                 #{udp_to_tcp:=true} ->
                     retry_tcp;
                 _ ->
-                    lager:notice("Error sending msg: udp_too_large", []),
+                    logger:notice("Error sending msg: udp_too_large", []),
                     do_send(Msg, Rest, Opts#{last_error=>udp_too_large})
             end;
         {error, Error} ->
-            lager:notice("Error sending msg to ~p: ~p", [Port, Error]),
+            logger:notice("Error sending msg to ~p: ~p", [Port, Error]),
             do_send(Msg, Rest, Opts#{last_error=>Error})
     end.
 
@@ -309,7 +309,7 @@ do_connect({Protocol, Transp, Ip, Port}, Opts) ->
         undefined when ListenOpt ->
             {error, no_listening_transport};
         _ ->
-            lager:debug("transport base port: ~p", [BasePort]),
+            logger:debug("transport base port: ~p", [BasePort]),
             % Our listening host and meta must not be used for the new connection
             Meta2 = maps:remove(host, Meta1),
             Meta3 = maps:remove(path, Meta2),
@@ -359,7 +359,7 @@ get_defport(Protocol, Transp) ->
                 Port when is_integer(Port), Port > 0 -> 
                     {ok, Port};
                 Other -> 
-                    lager:warning("Error calling ~p:default_port(~p): ~p",
+                    logger:warning("Error calling ~p:default_port(~p): ~p",
                                   [Protocol, Transp, Other]),
                     error
             end;
@@ -397,7 +397,7 @@ open_port(NkPort, Opts) ->
     end,
     case Port of
         0 when is_integer(DefPort) ->
-            lager:info("Opening ~p:~p (default, ~p)", [Module, DefPort, Opts]),
+            logger:info("Opening ~p:~p (default, ~p)", [Module, DefPort, Opts]),
             case Module:Fun(DefPort, Opts) of
                 {ok, Socket} ->
                     {ok, Socket};
@@ -415,12 +415,12 @@ open_port(NkPort, Opts) ->
     {ok, port()} | {error, term()}.
 
 open_port(Ip, Port, Module, Fun, Opts, Iter) ->
-    lager:info("Opening ~p:~p (~p)", [Module, Port, Opts]),
+    logger:info("Opening ~p:~p (~p)", [Module, Port, Opts]),
     case Module:Fun(Port, Opts) of
         {ok, Socket} ->
             {ok, Socket};
         {error, eaddrinuse} when Iter > 0 ->
-            lager:info("~p port ~p is in use, waiting (~p)", 
+            logger:info("~p port ~p is in use, waiting (~p)", 
                          [Module, Port, Iter]),
             timer:sleep(1000),
             open_port(Ip, Port, Module, Fun, Opts, Iter-1);

--- a/src/nkpacket_transport_http.erl
+++ b/src/nkpacket_transport_http.erl
@@ -140,7 +140,7 @@ init([NkPort]) ->
         {ok, State}
     catch
         throw:TError -> 
-            lager:error("could not start ~p transport on ~p:~p (~p)", 
+            logger:error("could not start ~p transport on ~p:~p (~p)", 
                    [Transp, Ip, Port, TError]),
         {stop, TError}
     end.
@@ -170,16 +170,16 @@ handle_call({nkpacket_start, Ip, Port, _UserMeta, Pid}, _From, State) ->
             % the cowboy process (using 'socket')
             case nkpacket_connection:start(NkPort1) of
                 {ok, #nkport{pid=ConnPid}=NkPort2} ->
-                    lager:debug("HTTP listener accepted connection: ~p", 
+                    logger:debug("HTTP listener accepted connection: ~p", 
                           [NkPort2]),
                     {reply, {ok, Protocol, HttpProto, ConnPid}, State};
                 {error, Error} ->
-                    lager:notice("HTTP listener did not accepted connection:"
+                    logger:notice("HTTP listener did not accepted connection:"
                             " ~p", [Error]),
                     {reply, next, State}
             end;
         false ->
-            lager:notice("HTTP protocol ~p missing", [Protocol]),
+            logger:notice("HTTP protocol ~p missing", [Protocol]),
             {reply, next, State}
     end;
 
@@ -217,7 +217,7 @@ handle_info({'DOWN', MRef, process, _Pid, _Reason}, #state{monitor_ref=MRef}=Sta
     {stop, normal, State};
 
 handle_info({'DOWN', _MRef, process, Pid, Reason}, #state{shared=Pid}=State) ->
-    % lager:warning("WS received SHARED stop"),
+    % logger:warning("WS received SHARED stop"),
     {stop, Reason, State};
 
 handle_info(Msg, #state{nkport=NkPort}=State) ->

--- a/src/nkpacket_transport_sctp.erl
+++ b/src/nkpacket_transport_sctp.erl
@@ -140,7 +140,7 @@ init([NkPort]) ->
             },
             {ok, State};
         {error, Error} ->
-            lager:error("could not start SCTP transport on ~p:~p (~p)", 
+            logger:error("could not start SCTP transport on ~p:~p (~p)", 
                    [Ip, Port, Error]),
             {stop, Error}
     end.
@@ -229,7 +229,7 @@ handle_info({sctp, Socket, Ip, Port, {Anc, SAC}}, State) ->
     #nkport{class=Class, protocol=Proto} = NkPort,
     State1 = case SAC of
         #sctp_assoc_change{state=comm_up, assoc_id=AssocId} ->
-            % lager:error("COMM_UP: ~p", [AssocId]),
+            % logger:error("COMM_UP: ~p", [AssocId]),
             #state{pending_froms=Froms} = State,
             case lists:keytake({Ip, Port}, 1, Froms) of
                 {value, {_, From, Meta}, Froms1} -> 
@@ -240,7 +240,7 @@ handle_info({sctp, Socket, Ip, Port, {Anc, SAC}}, State) ->
                     State
             end;
         #sctp_assoc_change{state=shutdown_comp, assoc_id=_AssocId} ->
-            % lager:error("COMM_DOWN: ~p", [AssocId]),
+            % logger:error("COMM_DOWN: ~p", [AssocId]),
             Conn = {Proto, sctp, Ip, Port},
             case nkpacket_transport:get_connected(Conn, #{class=>Class}) of
                 [Pid|_] -> nkpacket_connection:stop(Pid, normal);
@@ -259,11 +259,11 @@ handle_info({sctp, Socket, Ip, Port, {Anc, SAC}}, State) ->
                 {ok, #nkport{pid=Pid}} ->
                     nkpacket_connection:incoming(Pid, Data);
                 {error, Error} ->
-                    lager:notice("Error ~p on SCTP connection up", [Error])
+                    logger:notice("Error ~p on SCTP connection up", [Error])
             end,
             State;
         Other ->
-            lager:notice("SCTP unknown data from ~p, ~p: ~p", [Ip, Port, Other]),
+            logger:notice("SCTP unknown data from ~p, ~p: ~p", [Ip, Port, Other]),
             State
     end,
     ok = inet:setopts(Socket, [{active, once}]),
@@ -306,7 +306,7 @@ code_change(_OldVsn, State, _Extra) ->
     ok.
 
 terminate(Reason, #state{nkport=NkPort, socket=Socket}=State) ->  
-    lager:debug("SCTP server process stopped", []),
+    logger:debug("SCTP server process stopped", []),
     catch call_protocol(listen_stop, [Reason, NkPort], State),
     gen_sctp:close(Socket).
 

--- a/src/nkpacket_transport_tcp.erl
+++ b/src/nkpacket_transport_tcp.erl
@@ -69,7 +69,7 @@ connect(NkPort) ->
         undefined -> nkpacket_config_cache:connect_timeout();
         Timeout0 -> Timeout0
     end,
-    lager:debug("TCP connect to: ~p:~p:~p (~p)", [Transp, Ip, Port, SocketOpts]),
+    logger:debug("TCP connect to: ~p:~p:~p (~p)", [Transp, Ip, Port, SocketOpts]),
     case TranspMod:connect(Ip, Port, SocketOpts, ConnTimeout) of
         {ok, Socket} ->
             {ok, {LocalIp, LocalPort}} = InetMod:sockname(Socket),
@@ -219,7 +219,7 @@ terminate(Reason, State) ->
         ranch_pid = RanchPid,
         nkport = #nkport{transp=Transp, socket=Socket} = NkPort
     } = State,
-    lager:debug("TCP/TLS listener stop: ~p", [Reason]),
+    logger:debug("TCP/TLS listener stop: ~p", [Reason]),
     catch call_protocol(listen_stop, [Reason, NkPort], State),
     exit(RanchPid, shutdown),
     timer:sleep(100),   %% Give time to ranch to close acceptors

--- a/src/nkpacket_transport_ws.erl
+++ b/src/nkpacket_transport_ws.erl
@@ -172,7 +172,7 @@ init([NkPort]) ->
             _ -> 
                 undefined
         end,
-        lager:info("Created ~p listener for ~p:~p:~p (~p, ~p, ~p) (~p)", 
+        logger:info("Created ~p listener for ~p:~p:~p (~p, ~p, ~p) (~p)", 
                    [Protocol, Transp, LocalIp, LocalPort, 
                     Host, Path, WsProto, self()]),
         State = #state{
@@ -185,7 +185,7 @@ init([NkPort]) ->
         {ok, State}
     catch
         throw:TError -> 
-            lager:error("could not start ~p transport on ~p:~p (~p)", 
+            logger:error("could not start ~p transport on ~p:~p (~p)", 
                    [Transp, ListenIp, ListenPort, TError]),
         {stop, TError}
     end.
@@ -218,11 +218,11 @@ handle_call({nkpacket_start, Ip, Port, UserMeta, Pid}, _From, State) ->
     },
     case nkpacket_connection:start(NkPort1) of
         {ok, #nkport{pid=ConnPid}=NkPort2} ->
-            lager:debug("WS listener accepted connection: ~p", 
+            logger:debug("WS listener accepted connection: ~p", 
                   [NkPort2]),
             {reply, {ok, ConnPid}, State};
         {error, Error} ->
-            lager:notice("WS listener did not accepted connection:"
+            logger:notice("WS listener did not accepted connection:"
                     " ~p", [Error]),
             {reply, next, State}
     end;
@@ -261,7 +261,7 @@ handle_info({'DOWN', MRef, process, _Pid, _Reason}, #state{monitor_ref=MRef}=Sta
     {stop, normal, State};
 
 handle_info({'DOWN', _MRef, process, Pid, Reason}, #state{shared=Pid}=State) ->
-    % lager:warning("WS received SHARED stop"),
+    % logger:warning("WS received SHARED stop"),
     {stop, Reason, State};
 
 handle_info(Msg, #state{nkport=NkPort}=State) ->
@@ -349,7 +349,7 @@ websocket_handle({pong, Body}, Req, ConnPid) ->
     {ok, Req, ConnPid};
 
 websocket_handle(Other, Req, ConnPid) ->
-    lager:warning("WS Handler received unexpected ~p", [Other]),
+    logger:warning("WS Handler received unexpected ~p", [Other]),
     {stop, Req, ConnPid}.
 
 
@@ -384,13 +384,13 @@ websocket_info(nkpacket_stop, Req, State) ->
     {stop, Req, State};
 
 websocket_info(Info, Req, State) ->
-    lager:error("Module ~p received unexpected info ~p", [?MODULE, Info]),
+    logger:error("Module ~p received unexpected info ~p", [?MODULE, Info]),
     {ok, Req, State}.
 
 
 %% @private
 terminate(Reason, _Req, ConnPid) ->
-    lager:debug("WS ~p process terminate: ~p", [self(), Reason]),
+    logger:debug("WS ~p process terminate: ~p", [self(), Reason]),
     nkpacket_connection:stop(ConnPid, normal),
     ok.
 

--- a/src/nkpacket_util.erl
+++ b/src/nkpacket_util.erl
@@ -302,9 +302,8 @@ init_protocol(Protocol, Fun, Arg) ->
             try 
                 Protocol:Fun(Arg)
             catch
-                Class:Reason ->
-                    Stacktrace = erlang:get_stacktrace(),
-                    logger:error("Exception ~p (~p) calling ~p:~p(~p). Stack: ~p", 
+                Class:Reason:Stacktrace ->
+                    logger:error("Exception ~p (~p) calling ~p:~p(~p). Stack: ~p",
                                 [Class, Reason, Protocol, Fun, Arg, Stacktrace]),
                     erlang:Class([{reason, Reason}, {stacktrace, Stacktrace}])
             end
@@ -341,9 +340,8 @@ call_protocol(Fun, Args, State, Pos) ->
                         {Class, Value, setelement(Pos+1, State, ProtoState1)}
                 end
             catch
-                EClass:Reason ->
-                    Stacktrace = erlang:get_stacktrace(),
-                    logger:error("Exception ~p (~p) calling ~p:~p(~p). Stack: ~p", 
+                EClass:Reason:Stacktrace ->
+                    logger:error("Exception ~p (~p) calling ~p:~p(~p). Stack: ~p",
                                 [EClass, Reason, Protocol, Fun, Args, Stacktrace]),
                     erlang:EClass([{reason, Reason}, {stacktrace, Stacktrace}])
             end

--- a/src/nkpacket_util.erl
+++ b/src/nkpacket_util.erl
@@ -84,8 +84,7 @@ print_all([Id|Rest]) ->
         NkPort#nkport{socket=element(1,Socket)}; 
         false -> NkPort
     end,
-    {_, _, List} = lager:pr(NkPort1, ?MODULE),
-    io:format("~p\n", [List]),
+    io:format("~p\n", [NkPort1]),
     print_all(Rest).
 
 
@@ -305,7 +304,7 @@ init_protocol(Protocol, Fun, Arg) ->
             catch
                 Class:Reason ->
                     Stacktrace = erlang:get_stacktrace(),
-                    lager:error("Exception ~p (~p) calling ~p:~p(~p). Stack: ~p", 
+                    logger:error("Exception ~p (~p) calling ~p:~p(~p). Stack: ~p", 
                                 [Class, Reason, Protocol, Fun, Arg, Stacktrace]),
                     erlang:Class([{reason, Reason}, {stacktrace, Stacktrace}])
             end
@@ -327,7 +326,7 @@ call_protocol(Fun, Args, State, Pos) ->
         false when Fun==conn_handle_call; Fun==conn_handle_cast; 
                    Fun==conn_handle_info; Fun==listen_handle_call; 
                    Fun==listen_handle_cast; Fun==listen_handle_info ->
-            lager:error("Module ~p received unexpected ~p: ~p", [?MODULE, Fun, Args]),
+            logger:error("Module ~p received unexpected ~p: ~p", [?MODULE, Fun, Args]),
             undefined;
         false ->
             undefined;
@@ -344,7 +343,7 @@ call_protocol(Fun, Args, State, Pos) ->
             catch
                 EClass:Reason ->
                     Stacktrace = erlang:get_stacktrace(),
-                    lager:error("Exception ~p (~p) calling ~p:~p(~p). Stack: ~p", 
+                    logger:error("Exception ~p (~p) calling ~p:~p(~p). Stack: ~p", 
                                 [EClass, Reason, Protocol, Fun, Args, Stacktrace]),
                     erlang:EClass([{reason, Reason}, {stacktrace, Stacktrace}])
             end

--- a/test/app.config
+++ b/test/app.config
@@ -2,12 +2,6 @@
     {nkpacket, [
     ]},
 
-    {lager, [
-        {handlers, [{lager_console_backend, warning}]},
-        {error_logger_redirect, false},
-        {colored, true}
-    ]},
-
     {sasl, [
         {sasl_error_logger, false}
     ]}

--- a/test/http_test.erl
+++ b/test/http_test.erl
@@ -213,7 +213,7 @@ static() ->
     ] = lists:sort(H2),
 	{ok, 200, H3, <<"file1.txt">>} = get(Gun, "/dir1/file1.txt", []),
 	{ok, 200, H3, <<"file1.txt">>} = get(Gun, "/dir1/././file1.txt", []),
-	lager:warning("Next warning about unathorized access is expected"),
+	logger:warning("Next warning about unathorized access is expected"),
 	{ok, 400, _} = get(Gun, "/dir1/../../file1.txt", []),
 	{ok, 200, H3, <<"file1.txt">>} = get(Gun, "/dir1/../dir1/file1.txt", []),
 	[

--- a/test/ipv6_test.erl
+++ b/test/ipv6_test.erl
@@ -55,7 +55,7 @@ basic() ->
 	{ok, {_, tcp, _, LPort2}} = nkpacket:get_local(Tcp2),
 	case LPort2 of
 		1235 -> ok;
-		_ -> lager:warning("Could not open 1235")
+		_ -> logger:warning("Could not open 1235")
 	end,
 
 	timer:sleep(100),

--- a/test/tcp_test.erl
+++ b/test/tcp_test.erl
@@ -76,7 +76,7 @@ basic() ->
 	{ok, {_, _, _, ListenPort2}} = nkpacket:get_local(Tcp2),
 	case ListenPort1 of
 		1235 -> ok;
-		_ -> lager:warning("Could not open port 1235")
+		_ -> logger:warning("Could not open port 1235")
 	end,
 
 	Uri = "<test://localhost:"++integer_to_list(ListenPort1)++";transport=tcp>",
@@ -129,7 +129,7 @@ tls() ->
 	{ok, {_, _, _, ListenPort1}} = nkpacket:get_local(Tls1),
 	case ListenPort1 of
 		1236 -> ok;
-		_ -> lager:warning("Could not open port 1236")
+		_ -> logger:warning("Could not open port 1236")
 	end,
 	receive {Ref1, listen_init} -> ok after 1000 -> error(?LINE) end,
 	timer:sleep(1000),
@@ -211,7 +211,7 @@ send() ->
 	{ok, {_, udp, _, Listen2}} = nkpacket:get_local(Udp2),
 
 	% Invalid sends
-	lager:warning("Next warning about a invalid send specification is expected"),
+	logger:warning("Next warning about a invalid send specification is expected"),
 	{error, {invalid_send_specification, wrong}} = nkpacket:send(wrong, msg1),
 	{error, no_transports} =
 		nkpacket:send({current, {test_protocol, tcp, {0,0,0,0}, Listen2}}, msg1),

--- a/test/test_protocol.erl
+++ b/test/test_protocol.erl
@@ -70,7 +70,7 @@ default_port(_) -> invalid.
 	#listen_state{}.
 
 listen_init(NkPort) ->
-	lager:info("Protocol LISTEN init: ~p (~p)", [NkPort, self()]),
+	logger:info("Protocol LISTEN init: ~p (~p)", [NkPort, self()]),
 	State = case nkpacket:get_user(NkPort) of
 		{ok, _Class, {Pid, Ref}} -> 
 			#listen_state{pid=Pid, ref=Ref};
@@ -82,12 +82,12 @@ listen_init(NkPort) ->
 
 
 listen_handle_call(Msg, _From, _NkPort, State) ->
-	lager:warning("Unexpected call: ~p", [Msg]),
+	logger:warning("Unexpected call: ~p", [Msg]),
 	{ok, State}.
 
 
 listen_handle_cast(Msg, _NkPort, State) ->
-	lager:warning("Unexpected cast: ~p", [Msg]),
+	logger:warning("Unexpected cast: ~p", [Msg]),
 	{ok, State}.
 
 
@@ -95,16 +95,16 @@ listen_handle_info({'EXIT', _, forced_stop}, _NkPort, State) ->
 	{stop, forced_stop, State};
 
 listen_handle_info(Msg, _NkPort, State) ->
-	lager:warning("Unexpected listen info: ~p", [Msg]),
+	logger:warning("Unexpected listen info: ~p", [Msg]),
 	{ok, State}.
 
 listen_parse(Ip, Port, Data, _NkPort, State) ->
-	lager:info("LISTEN Parsing fromm ~p:~p: ~p", [Ip, Port, Data]),
+	logger:info("LISTEN Parsing fromm ~p:~p: ~p", [Ip, Port, Data]),
 	maybe_reply({listen_parse, Data}, State),
 	{ok, State}.
 
 listen_stop(Reason, _NkPort, State) ->
-	lager:info("LISTEN  stop: ~p, ~p", [Reason, State]),
+	logger:info("LISTEN  stop: ~p, ~p", [Reason, State]),
 	maybe_reply(listen_stop, State),
 	ok.
 
@@ -123,7 +123,7 @@ listen_stop(Reason, _NkPort, State) ->
 	{ok, #conn_state{}}.
 
 conn_init(NkPort) ->
-	lager:info("Protocol CONN init: ~p (~p)", [NkPort, self()]),
+	logger:info("Protocol CONN init: ~p (~p)", [NkPort, self()]),
 	State = case nkpacket:get_user(NkPort) of
 		{ok, _Class, {Pid, Ref}} -> #conn_state{pid=Pid, ref=Ref};
 		_ -> #conn_state{}
@@ -133,18 +133,18 @@ conn_init(NkPort) ->
 
 
 conn_parse({text, Data}, _NkPort, State) ->
-	lager:debug("Parsing WS TEXT: ~p", [Data]),
+	logger:debug("Parsing WS TEXT: ~p", [Data]),
 	maybe_reply({parse, {text, Data}}, State),
 	{ok, State};
 
 conn_parse({binary, <<>>}, _NkPort, State) ->
-	lager:error("EMPTY"),
+	logger:error("EMPTY"),
 	{ok, State};
 
 
 conn_parse({binary, Data}, _NkPort, State) ->
 	Msg = erlang:binary_to_term(Data),
-	lager:debug("Parsing WS BIN: ~p", [Msg]),
+	logger:debug("Parsing WS BIN: ~p", [Msg]),
 	maybe_reply({parse, {binary, Msg}}, State),
 	{ok, State};
 
@@ -155,49 +155,49 @@ conn_parse(pong, _NkPort, State) ->
 	{ok, State};
 
 conn_parse({pong, Payload}, _NkPort, State) ->
-	lager:debug("Parsing WS PONG: ~p", [Payload]),
+	logger:debug("Parsing WS PONG: ~p", [Payload]),
 	maybe_reply({pong, Payload}, State),
 	{ok, State};
 
 conn_parse(Data, #nkport{class=Class}, State) ->
 	Msg = erlang:binary_to_term(Data),
-	lager:debug("Parsing: ~p (~p)", [Msg, Class]),
+	logger:debug("Parsing: ~p (~p)", [Msg, Class]),
 	maybe_reply({parse, Msg}, State),
 	{ok, State}.
 
 conn_encode({nkraw, Msg}, NkPort, State) ->
-	lager:debug("UnParsing RAW: ~p, ~p", [Msg, NkPort]),
+	logger:debug("UnParsing RAW: ~p, ~p", [Msg, NkPort]),
 	maybe_reply({encode, Msg}, State),
 	{ok, Msg, State};
 
 conn_encode(Msg, NkPort, State) ->
-	lager:debug("UnParsing: ~p, ~p", [Msg, NkPort]),
+	logger:debug("UnParsing: ~p, ~p", [Msg, NkPort]),
 	maybe_reply({encode, Msg}, State),
 	{ok, erlang:term_to_binary(Msg), State}.
 
 conn_handle_call(Msg, _From, _NkPort, State) ->
-	lager:warning("Unexpected call: ~p", [Msg]),
+	logger:warning("Unexpected call: ~p", [Msg]),
 	{ok, State}.
 
 
 conn_handle_cast(Msg, _NkPort, State) ->
-	lager:warning("Unexpected cast: ~p", [Msg]),
+	logger:warning("Unexpected cast: ~p", [Msg]),
 	{ok, State}.
 
 
 conn_handle_info(Msg, _NkPort, State) ->
-	lager:warning("Unexpected conn info: ~p", [Msg]),
+	logger:warning("Unexpected conn info: ~p", [Msg]),
 	{ok, State}.
 
 conn_stop(Reason, _NkPort, State) ->
-	lager:info("CONN stop: ~p", [Reason]),
+	logger:info("CONN stop: ~p", [Reason]),
 	maybe_reply(conn_stop, State),
 	ok.
 
 
 
 % encode(Msg, NkPort) ->
-% 	lager:info("Quick UnParsing: ~p, ~p", [Msg, NkPort]),
+% 	logger:info("Quick UnParsing: ~p, ~p", [Msg, NkPort]),
 % 	{ok, erlang:term_to_binary(Msg)}.
 
 

--- a/test/udp_test.erl
+++ b/test/udp_test.erl
@@ -53,7 +53,7 @@ basic() ->
 	{ok, {_, udp, {0,0,0,0}, Port1}} = nkpacket:get_local(UdpP1),
 	case Port1 of
 		1234 -> ok;
-		_ -> lager:warning("Could not open port 1234")
+		_ -> logger:warning("Could not open port 1234")
 	end,
 	[Listen1] = nkpacket:get_all(),
 	[Listen1] = nkpacket:get_all(none),
@@ -80,7 +80,7 @@ basic() ->
 		#nkport{transp=udp, local_port=Port2, pid=LisA}
 	] = test_util:listeners(dom2),
 
-	lager:warning("Some processes will be killed now..."),
+	logger:warning("Some processes will be killed now..."),
 	% Should also work with kill
 	% exit(ConnA, kill),
 	exit(ConnA, forced_stop),

--- a/test/vm.args
+++ b/test/vm.args
@@ -1,4 +1,3 @@
--pa deps/lager/ebin
 -pa deps/goldrush/ebin
 -pa deps/jiffy/ebin
 -pa deps/cowboy/ebin

--- a/test/ws_test.erl
+++ b/test/ws_test.erl
@@ -56,7 +56,7 @@ basic() ->
 	{ok, {_, ws, {0,0,0,0}, LPort1}} = nkpacket:get_local(Ws1),
 	case LPort1 of
 		1238 -> ok;
-		_ -> lager:warning("Could not open port 1238")
+		_ -> logger:warning("Could not open port 1238")
 	end,
 	receive {Ref1, listen_init} -> ok after 1000 -> error(?LINE) end,
 	[
@@ -163,7 +163,7 @@ wss() ->
 	{ok, {_, wss, {0,0,0,0}, LPort1}} = nkpacket:get_local(Ws1),
 	case LPort1 of
 		1239 -> ok;
-		_ -> lager:warning("Could not open port 1239")
+		_ -> logger:warning("Could not open port 1239")
 	end,
 	[
 		#nkport{

--- a/util/shell_app.config
+++ b/util/shell_app.config
@@ -4,24 +4,5 @@
 
     {sasl, [
         {sasl_error_logger, false}
-    ]},
-
-    {lager, [
-        {handlers, [
-            {lager_console_backend, info},
-            {lager_file_backend, [{file, "log/error.log"}, {level, error}]},
-            {lager_file_backend, [{file, "log/console.log"}, {level, info}]}
-        ]},
-        {error_logger_redirect, false},
-        {crash_log, "log/crash.log"},
-        {colored, true},
-        {colors, [
-            {debug,     "\e[0;38m" },
-            {info,      "\e[0;32m" },
-            {notice,    "\e[1;36m" },
-            {warning,   "\e[1;33m" },
-            {error,     "\e[1;31m" }
-        ]}
     ]}
-
 ].

--- a/util/shell_vm.args
+++ b/util/shell_vm.args
@@ -1,4 +1,3 @@
--pa deps/lager/ebin
 -pa deps/goldrush/ebin
 -pa deps/jsx/ebin
 -pa deps/jiffy/ebin


### PR DESCRIPTION
The goal is to replace `lager` with Erlang `logger` in order to remove the `lager` dependency from [MongooseIM](https://github.com/esl/mongooseim/), and integrate the output with the MongooseIM logs.

It is not required to maintain all functionality that was present before, but only to keep the library functional enough to be used in the `mod_jingle_sip` module in MongooseIM. The changes are verified by the corresponding [PR to MongooseIM](https://github.com/esl/MongooseIM/pull/4393).

Additionally:
- Make `rebar3 compile` work on Erlang 27.
- Fix use of removed `erlang:get_stacktrace/0`.